### PR TITLE
Fix version number for support of either prefixed 'vX.Y.Z' or not prefixed 'X.Y.Z'

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -17,8 +17,8 @@ install_tool() {
   local download_path
 
   platform=$(get_platform)
-  download_url=$(get_download_url "$version" "$platform" "$binary_name")
-  download_path="$tmp_download_dir/"$(get_filename "$version" "$platform" "$binary_name")
+  download_url=$(get_download_url "v${version#v}" "$platform" "$binary_name")
+  download_path="$tmp_download_dir/"$(get_filename "v${version#v}" "$platform" "$binary_name")
 
   echo "Downloading [${binary_name}] from ${download_url} to ${download_path}"
   curl -Lo "$download_path" "$download_url"
@@ -30,7 +30,7 @@ install_tool() {
   rm -f "$binary_path" 2>/dev/null || true
 
   echo "Copying binary"
-  cp "$(get_binary_path_in_archive "${tmp_download_dir}" "${binary_name}" "${version}" "${platform}")" "${binary_path}"
+  cp "$(get_binary_path_in_archive "${tmp_download_dir}" "${binary_name}" "v${version#v}" "${platform}")" "${binary_path}"
   chmod +x "${binary_path}"
 }
 


### PR DESCRIPTION
Many asdf plugins support a true semantic versioning number, no matter how the underlying tool releases.
This small change can enable to reference  in `.tool-versions` a version number with either the 'v' prefix or without.